### PR TITLE
`list-filter-expr` is a `bracket-specifier`.

### DIFF
--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -47,7 +47,7 @@
 ;;
 ;; %%GRAMMAR%%
 
-expression        = sub-expression / index-expression  / comparator-expression / list-filter-expr
+expression        = sub-expression / index-expression  / comparator-expression
 expression        =/ or-expression / identifier
 expression        =/ and-expression / not-expression / paren-expression
 expression        =/ multi-select-list / multi-select-hash / literal
@@ -379,6 +379,7 @@ bracket-specifier =/ "[" "*" "]"
 ;; search('*.foo', {"a": {"foo": 1}, "b": {"foo": 2}, "c": {"bar": 1}}) -> [1, 2]
 ;; ```
 
+bracket-specifier =/ list-filter-expr
 list-filter-expr = "[?" expression "]" ;; # Filter Expressions \
 comparator-expression = expression comparator expression ;; \
 comparator        = "<" / "<=" / "==" / ">=" / ">" / "!="

--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -379,8 +379,8 @@ bracket-specifier =/ "[" "*" "]"
 ;; search('*.foo', {"a": {"foo": 1}, "b": {"foo": 2}, "c": {"bar": 1}}) -> [1, 2]
 ;; ```
 
-bracket-specifier =/ list-filter-expr
 list-filter-expr = "[?" expression "]" ;; # Filter Expressions \
+bracket-specifier =/ list-filter-expr ;; \
 comparator-expression = expression comparator expression ;; \
 comparator        = "<" / "<=" / "==" / ">=" / ">" / "!="
 ;; A filter expression provides a way to select JSON elements based on a comparison to another expression. A filter


### PR DESCRIPTION
The current [`GRAMMAR`](https://github.com/jmespath-community/jmespath.spec/blob/main/GRAMMAR.ABNF) does not allow expressions like:

`` foo[?bar == 'baz'] ``

As it would parse as an `identifier` followed by a `list-filter-expr`.
However, this expression is perfectly valid and supported in all current library implementations.
This suggests that the grammar is slightly wrong.

This PR changes the grammar like so:

- It removes the `list-filter-expr` from the list of explicit alternatives for the `expression` rule.
- It includes the `list-filter-expr` as an alternative for the `bracket-specifier` rule.

In effect, this turns the referred to expression above as an `index-expression`.

