### PR TITLE
`index-expression` should be allowed on the rhs of a `sub-expression`.

### DIFF
--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -53,7 +53,7 @@ expression        =/ and-expression / not-expression / paren-expression
 expression        =/ multi-select-list / multi-select-hash / literal
 expression        =/ function-expression / pipe-expression / raw-string
 expression        =/ current-node
-sub-expression    = expression "." ( identifier / multi-select-list / multi-select-hash / function-expression / "*" ) ;; # Sub-expressions
+sub-expression    = expression "." ( identifier / index-expression / multi-select-list / multi-select-hash / function-expression / "*" ) ;; # Sub-expressions
 ;; A sub-expression is a combination of two expressions separated by the '.' char. A sub-expression is evaluated as follows:
 ;;
 ;; - Evaluate the expression on the left with the original JSON document.


### PR DESCRIPTION
The current [`GRAMMAR`](https://github.com/jmespath-community/jmespath.spec/blob/main/GRAMMAR.ABNF) does not allow expressions like:

`` foo.bar[0] ``

As it would parse as a `sub-expression` where the right-hand-side part is an `index-expression`.
However, this expression is perfectly valid and supported in all current library implementations.
This suggests that the grammar is slightly wrong.

This PR changes the grammar like so:

- It includes the `index-expression` as an alternative in the right-hand-side list for the `sub-expression` rule.


