### PR TITLE
Document "to_array(null)"

### DIFF
--- a/functions/to_array.yml
+++ b/functions/to_array.yml
@@ -11,8 +11,7 @@ returns:
   desc: ''
 desc: |
   * array - Returns the passed in value.
-
-  * number/string/object/boolean - Returns a one element array containing
+  * number/string/object/boolean/null - Returns a one element array containing
   the passed in argument.
 examples:
   test0:


### PR DESCRIPTION
This PR documents existing behaviour of the `to_array()` function when applied to a `null` value,

Thus:

- `` search( to_array(`null`), {} ) -> [ null ] ``