### PR TITLE
JSON grammar rules are inconsistent.

### DIFF
--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -601,7 +601,7 @@ unquoted-string   = (%x41-5A / %x61-7A / %x5F) *(  ; A-Za-z_
                         %x5F    /  ; _
                         %x61-7A)   ; a-z
 quoted-string     = quote 1*(unescaped-char / escaped-char) quote
-unescaped-char    = %x20-21 / %x23-5B / %x5D-10FFFF
+unescaped-char    = %x20-21 / %x23-2E / %30-5B / %x5D-10FFFF
 escape            = "\"
 quote             = %x22   ; Double quote: '"'
 escaped-char      = escape (


### PR DESCRIPTION
The JMESPath grammar mostly includes rules for parsing valid JSON texts.
However, the JSON RFC includes [errata](https://www.rfc-editor.org/errata/eid5318) that were not included in this spec.

In particular, the two `unescaped-char` and `escaped-char` rules are inconsistent:

```abnf
quoted-string     = quote 1*(unescaped-char / escaped-char) quote
unescaped-char    = %x20-21 / %x23-5B / %x5D-10FFFF
escape            = "\"
quote             = %x22   ; Double quote: '"'
escaped-char      = escape (
                        %x22 /          ; "    quotation mark  U+0022
                        %x5C /          ; \    reverse solidus U+005C
                        %x2F /          ; /    solidus         U+002F
                        %x62 /          ; b    backspace       U+0008
                        %x66 /          ; f    form feed       U+000C
                        %x6E /          ; n    line feed       U+000A
                        %x72 /          ; r    carriage return U+000D
                        %x74 /          ; t    tab             U+0009
                        %x75 4HEXDIG )  ; uXXXX                U+XXXX

```

The `/` U+002F SOLIDUS character is present in those two rules.
It should, however, be excluded from the `unsecaped-char` rule.

This PR fixes this issue.