### PR TITLE
Simplified syntax where possible.

### DIFF
--- a/functions/abs.yml
+++ b/functions/abs.yml
@@ -3,9 +3,8 @@ topic: math
 args:
   required:
   - name: value
-    type: [number]
+    type: number
     desc: positive or negative number
-  optional: []
 returns:
   type: number
   desc: positive magnitude of input value

--- a/functions/avg.yml
+++ b/functions/avg.yml
@@ -3,9 +3,8 @@ topic: math
 args:
   required:
   - name: elements
-    type: ['array[number]']
+    type: 'array[number]'
     desc: array of numbers to calculate average from
-  optional: []
 returns:
   type: [number, 'null']
   desc: average value of passed elements

--- a/functions/ceil.yml
+++ b/functions/ceil.yml
@@ -3,12 +3,9 @@ topic: math
 args:
   required:
   - name: value
-    type: [number]
-    desc: ''
-  optional: []
+    type: number
 returns:
   type: number
-  desc: ''
 desc: |
   Returns the next highest integer value by rounding up if necessary.
 examples:

--- a/functions/contains.yml
+++ b/functions/contains.yml
@@ -4,14 +4,11 @@ args:
   required:
   - name: subject
     type: [array, string]
-    desc: ''
   - name: search
-    type: [any]
-    desc: ''
-  optional: []
+    type: any
+
 returns:
   type: boolean
-  desc: ''
 desc: |
   Returns `true` if the given `$subject` contains the provided `$search`
   string.

--- a/functions/ends_with.yml
+++ b/functions/ends_with.yml
@@ -3,15 +3,11 @@ topic: strings
 args:
   required:
   - name: subject
-    type: [string]
-    desc: ''
+    type: string
   - name: prefix
-    type: [string]
-    desc: ''
-  optional: []
+    type: string
 returns:
   type: boolean
-  desc: ''
 desc: |
   Returns `true` if the `$subject` ends with the `$prefix`, otherwise this
   function returns `false`.

--- a/functions/floor.yml
+++ b/functions/floor.yml
@@ -3,12 +3,9 @@ topic: math
 args:
   required:
   - name: value
-    type: [number]
-    desc: ''
-  optional: []
+    type: number
 returns:
   type: number
-  desc: ''
 desc: |
   Returns the next lowest integer value by rounding down if necessary.
 examples:

--- a/functions/from_items.yml
+++ b/functions/from_items.yml
@@ -5,7 +5,6 @@ args:
   - name: arg
     type: ['array[any]']
     desc: ''
-  optional: []
 returns:
   type: [object]
   desc: ''

--- a/functions/group_by.yml
+++ b/functions/group_by.yml
@@ -3,15 +3,11 @@ topic: collections
 args:
   required:
   - name: elements
-    type: ['array[object]']
-    desc: ''
+    type: 'array[object]'
   - name: expr
-    type: [expression->string]
-    desc: ''
-  optional: []
+    type: expression->string
 returns:
   type: object
-  desc: ''
 desc: |
   Groups an array of objects `$elements` using an expression `$expr` as the group key.
   The `$expr` expression is applied to each element in the array `$elements` and the 

--- a/functions/items.yml
+++ b/functions/items.yml
@@ -3,12 +3,9 @@ topic: misc
 args:
   required:
   - name: obj
-    type: [object]
-    desc: ''
-  optional: []
+    type: object
 returns:
-  type: ['array[any]']
-  desc: ''
+  type: 'array[any]'
 desc: |2
   Returns an array of key-value pairs for the provided input object.
   Each pair is a 2-item array with the first item being the key and

--- a/functions/join.yml
+++ b/functions/join.yml
@@ -3,15 +3,11 @@ topic: collections
 args:
   required:
   - name: glue
-    type: [string]
-    desc: ''
+    type: string
   - name: stringsarray
-    type: ['array[string]']
-    desc: ''
-  optional: []
+    type: 'array[string]'
 returns:
   type: string
-  desc: ''
 desc: |
   Returns all of the elements from the provided `$stringsarray` array joined
   together using the `$glue` argument as a separator between each.

--- a/functions/keys.yml
+++ b/functions/keys.yml
@@ -3,12 +3,9 @@ topic: collections
 args:
   required:
   - name: obj
-    type: [object]
-    desc: ''
-  optional: []
+    type: object
 returns:
   type: array
-  desc: ''
 desc: |
   Returns an array containing the keys of the provided object.
   Note that because JSON hashes are inheritently unordered, the

--- a/functions/length.yml
+++ b/functions/length.yml
@@ -4,11 +4,8 @@ args:
   required:
   - name: subject
     type: [string, array, object]
-    desc: ''
-  optional: []
 returns:
   type: number
-  desc: ''
 desc: |
   Returns the length of the given argument using the following types rules:
 

--- a/functions/let.yml
+++ b/functions/let.yml
@@ -3,14 +3,11 @@ topic: misc
 args:
   required:
   - name: scope
-    type: [object]
-    desc: ''
+    type: object
   - name: expr
-    type: ['expression->any']
-  optional: []
+    type: 'expression->any'
 returns:
   type: any
-  desc: ''
 desc: |
 
   Captures the current evaluation context in a child lexical scope.

--- a/functions/map.yml
+++ b/functions/map.yml
@@ -3,15 +3,11 @@ topic: collections
 args:
   required:
   - name: expr
-    type: [expression]
-    desc: ''
+    type: expression
   - name: elements
-    type: ['array[any]']
-    desc: ''
-  optional: []
+    type: 'array[any]'
 returns:
   type: array[any]
-  desc: ''
 desc: |
   Apply the `expr` to every element in the `elements` array
   and return the array of results.  An `elements` of length

--- a/functions/max.yml
+++ b/functions/max.yml
@@ -4,11 +4,8 @@ args:
   required:
   - name: collection
     type: ['array[number]', 'array[string]']
-    desc: ''
-  optional: []
 returns:
   type: number
-  desc: ''
 desc: |
   Returns the highest found number in the provided array argument.
 

--- a/functions/max_by.yml
+++ b/functions/max_by.yml
@@ -3,15 +3,11 @@ topic: math
 args:
   required:
   - name: elements
-    type: [array]
-    desc: ''
+    type: array
   - name: expr
     type: [expression->number, expression->string]
-    desc: ''
-  optional: []
 returns:
   type: any
-  desc: ''
 desc: |
   Return the maximum element in an array using the expression `expr` as the
   comparison key.  The entire maximum element is returned.

--- a/functions/merge.yml
+++ b/functions/merge.yml
@@ -3,15 +3,11 @@ topic: collections
 args:
   required:
   - name: argument
-    type: [object]
-    desc: ''
-  optional:
-  - name: ..
-    type: [object]
-    desc: ''
+    type: object
+  variadic:
+    type: object
 returns:
   type: object
-  desc: ''
 desc: |
   Accepts 0 or more objects as arguments, and returns a single object
   with subsequent objects merged.  Each subsequent object’s key/value

--- a/functions/min.yml
+++ b/functions/min.yml
@@ -4,11 +4,8 @@ args:
   required:
   - name: collection
     type: ['array[number]', 'array[string]']
-    desc: ''
-  optional: []
 returns:
   type: number
-  desc: ''
 desc: |
   Returns the lowest found number in the provided `$collection` argument.
 examples:

--- a/functions/min_by.yml
+++ b/functions/min_by.yml
@@ -3,15 +3,11 @@ topic: math
 args:
   required:
   - name: elements
-    type: [array]
-    desc: ''
+    type: array
   - name: expr
     type: [expression->number, expression->string]
-    desc: ''
-  optional: []
 returns:
   type: any
-  desc: ''
 desc: |
   Return the minimum element in an array using the expression `expr` as the
   comparison key.  The entire maximum element is returned.

--- a/functions/not_null.yml
+++ b/functions/not_null.yml
@@ -3,15 +3,11 @@ topic: misc
 args:
   required:
   - name: argument
-    type: [any]
-    desc: ''
-  optional:
-  - name: ..
-    type: [any]
-    desc: ''
+    type: any
+  variadic:
+  - type: any
 returns:
   type: any
-  desc: ''
 desc: |
   Returns the first argument that does not resolve to `null`.  This function
   accepts one or more arguments, and will evaluate them in order until a

--- a/functions/reverse.yml
+++ b/functions/reverse.yml
@@ -4,11 +4,8 @@ args:
   required:
   - name: argument
     type: [string, array]
-    desc: ''
-  optional: []
 returns:
   type: array
-  desc: ''
 desc: |
   Reverses the order of the `$argument`.
 examples:

--- a/functions/sort.yml
+++ b/functions/sort.yml
@@ -4,11 +4,8 @@ args:
   required:
   - name: list
     type: ['array[number]', 'array[string]']
-    desc: ''
-  optional: []
 returns:
   type: array
-  desc: ''
 desc: |
   This function accepts an array `$list` argument and returns the sorted
   elements of the `$list` as an array.

--- a/functions/sort_by.yml
+++ b/functions/sort_by.yml
@@ -3,15 +3,11 @@ topic: collections
 args:
   required:
   - name: elements
-    type: [array]
-    desc: ''
+    type: array
   - name: expr
     type: [expression->number, expression->string]
-    desc: ''
-  optional: []
 returns:
   type: array
-  desc: ''
 desc: |
   Sort an array using an expression `expr` as the sort key.  For each element
   in the array of `elements`, the `expr` expression is applied and the

--- a/functions/starts_with.yml
+++ b/functions/starts_with.yml
@@ -3,15 +3,11 @@ topic: strings
 args:
   required:
   - name: subject
-    type: [string]
-    desc: ''
+    type: string
   - name: prefix
-    type: [string]
-    desc: ''
-  optional: []
+    type: string
 returns:
   type: boolean
-  desc: ''
 desc: |
   Returns `true` if the `$subject` starts with the `$prefix`, otherwise
   this function returns `false`.

--- a/functions/sum.yml
+++ b/functions/sum.yml
@@ -3,12 +3,9 @@ topic: math
 args:
   required:
   - name: collection
-    type: ['array[number]']
-    desc: ''
-  optional: []
+    type: 'array[number]'
 returns:
   type: number
-  desc: ''
 desc: |
   Returns the sum of the provided array argument.
 

--- a/functions/to_array.yml
+++ b/functions/to_array.yml
@@ -3,12 +3,9 @@ topic: conversion
 args:
   required:
   - name: arg
-    type: [any]
-    desc: ''
-  optional: []
+    type: any
 returns:
   type: array
-  desc: ''
 desc: |
   * array - Returns the passed in value.
   * number/string/object/boolean/null - Returns a one element array containing

--- a/functions/to_number.yml
+++ b/functions/to_number.yml
@@ -3,12 +3,9 @@ topic: conversion
 args:
   required:
   - name: arg
-    type: [any]
-    desc: ''
-  optional: []
+    type: any
 returns:
   type: number
-  desc: ''
 desc: |
   * string - Returns the parsed number.  Any string that conforms to the
   `json-number` production is supported.  Note that the floating number

--- a/functions/to_string.yml
+++ b/functions/to_string.yml
@@ -3,12 +3,9 @@ topic: conversion
 args:
   required:
   - name: arg
-    type: [any]
-    desc: ''
-  optional: []
+    type: any
 returns:
   type: string
-  desc: ''
 desc: |2
 
   * string - Returns the passed in value.

--- a/functions/type.yml
+++ b/functions/type.yml
@@ -3,12 +3,9 @@ topic: misc
 args:
   required:
   - name: subject
-    type: [array, object, string, number, boolean, 'null']
-    desc: ''
-  optional: []
+    type: any
 returns:
   type: string
-  desc: ''
 desc: |
   Returns the JavaScript type of the given `$subject` argument as a string
   value.

--- a/functions/values.yml
+++ b/functions/values.yml
@@ -3,12 +3,9 @@ topic: collections
 args:
   required:
   - name: obj
-    type: [object]
-    desc: ''
-  optional: []
+    type: object
 returns:
   type: array
-  desc: ''
 desc: |
   Returns the values of the provided object.
   Note that because JSON hashes are inheritently unordered, the

--- a/functions/zip.yml
+++ b/functions/zip.yml
@@ -3,15 +3,11 @@ topic: misc
 args:
   required:
   - name: arg
-    type: ['array[any]']
-    desc: ''
+    type: 'array[any]'
   variadic:
-    type: ['array[any]']
-    desc: ''
-  optional: []
+    type: 'array[any]'
 returns:
   type: ['array[array[any]]']
-  desc: ''
 desc: |2
   Accepts one or more arrays as arguments and returns an array of arrays
   in which the _i-th_ array contains the _i-th_ element from each of the


### PR DESCRIPTION
Most `desc` properties were empty and have now been omitted.
The `optional` argument array is also omitted when specified as empty.
Arguments with a single datatype have been simplified to a string instead of an array.