### PR TITLE
Reworked find_last() functions for consistency 

### DIFF
--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -21,7 +21,7 @@ int find_first(string $subject, string $sub[, int $start[, int $end]])
 ```
 Given the `$subject` string, `find_first()` returns the zero-based index of the first occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear.
 
-The `$start` and `$end` parameters are optional and allow restricting the range within `$subject` in which `$sub` must be found.
+The `$start` and `$end` parameters are optional and allow restricting to the slice `[$start:$end]` the range within `$subject` in which `$sub` must be found.
 
 - If `$start` is omitted, it defaults to `0` (which is the start of the `$subject` string).
 - If `$end` is omitted, it defaults to `length(subject)` (which is past the end of the `$subject` string).
@@ -46,14 +46,16 @@ Contrary to similar functions found in most popular programming languages, the `
 ### find_last
 
 ```
-int find_last(string $subject, string $sub[, int $pos])
+int find_last(string $subject, string $sub[, int $start[, $end]])
 ```
 Given the `$subject` string, `find_last()` returns the zero-based index of the last occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear.
 
-The `$pos` parameter is optional and allows restricting the maximum index within `$subject` at which to search for `$sub`.
-If this is parameter omitted, it defaults to `length(subject) - 1` (which is is the end of the `$subject` string).
+The `$start` and `$end` parameters are optional and allow restricting to the slice `[$start:$end]` the range within `$subject` in which `$sub` must be found.
 
-Contrary to similar functions found in most popular programming languages, the `find_last()` function does not return `-1` if no occurrence of the substring can be found. Instead, it returns `null` for consistency reasons with how JMESPath behaves.
+- If `$start` is omitted, it defaults to `0` (which is the start of the `$subject` string).
+- If `$end` is omitted, it defaults to `length(subject)` (which is past the end of the `$subject` string).
+
+Contrary to similar functions found in most popular programming languages, the `find_first()` function does not return `-1` if no occurrence of the substring can be found. Instead, it returns `null` for consistency reasons with how JMESPath behaves.
 
 ### Examples
 
@@ -61,9 +63,10 @@ Contrary to similar functions found in most popular programming languages, the `
 |---|---|---
 | `"subject string"` | `` find_last(@, 'string') `` |  `8`
 | `"subject string"` | `` find_last(@, 'string', 8) `` |  `8`
-| `"subject string"` | `` find_last(@, 'string', 7) `` |  `null`
-| `"subject string"` | `` find_last(@, 's', 8) `` |  `8`
-| `"subject string"` | `` find_last(@, 's', 7) `` |  `0`
+| `"subject string"` | `` find_last(@, 'string', 8, 9) `` |  `null`
+| `"subject string"` | `` find_last(@, 'string', 9) `` |  `null`
+| `"subject string"` | `` find_last(@, 's', 1) `` |  `8`
+| `"subject string"` | `` find_last(@, 's') `` |  `0`
 
 ### lower
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -19,7 +19,7 @@ This JEP introduces a core set of useful string manipulation functions. Those fu
 ```
 int find_first(string $subject, string $sub[, int $start[, int $end]])
 ```
-Given the `$subject` string, `find_first()` returns the zero-based index of the first occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear.
+Given the `$subject` string, `find_first()` returns the zero-based index of the first occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_first()` return `null`.
 
 The `$start` and `$end` parameters are optional and allow restricting to the slice `[$start:$end]` the range within `$subject` in which `$sub` must be found.
 
@@ -48,7 +48,7 @@ Contrary to similar functions found in most popular programming languages, the `
 ```
 int find_last(string $subject, string $sub[, int $start[, $end]])
 ```
-Given the `$subject` string, `find_last()` returns the zero-based index of the last occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear.
+Given the `$subject` string, `find_last()` returns the zero-based index of the last occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_first()` return `null`.
 
 The `$start` and `$end` parameters are optional and allow restricting to the slice `[$start:$end]` the range within `$subject` in which `$sub` must be found.
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -19,7 +19,7 @@ This JEP introduces a core set of useful string manipulation functions. Those fu
 ```
 int find_first(string $subject, string $sub[, int $start[, int $end]])
 ```
-Given the `$subject` string, `find_first()` returns the zero-based index of the first occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_first()` return `null`.
+Given the `$subject` string, `find_first()` returns the zero-based index of the first occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_first()` returns `null`.
 
 The `$start` and `$end` parameters are optional and allow restricting to the slice `[$start:$end]` the range within `$subject` in which `$sub` must be found.
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -36,8 +36,10 @@ Contrary to similar functions found in most popular programming languages, the `
 | `"subject string"` | `` find_first(@, 'string', `0`) `` |  `8`
 | `"subject string"` | `` find_first(@, 'string', `0`, `14`) `` |  `8`
 | `"subject string"` | `` find_first(@, 'string', `-99`, `100`) `` |  `8`
+| `"subject string"` | `` find_first(@, 'string', `-6`) `` |  `8`
 | `"subject string"` | `` find_first(@, 'string', `0`, `13`) `` |  `null`
 | `"subject string"` | `` find_first(@, 'string', `8`) `` |  `8`
+| `"subject string"` | `` find_first(@, 'string', `8`, `11`) `` |  `null`
 | `"subject string"` | `` find_first(@, 'string', `9`) `` |  `null`
 | `"subject string"` | `` find_first(@, 's') `` |  `0`
 | `"subject string"` | `` find_first(@, 's', `1`) `` |  `8`
@@ -68,6 +70,7 @@ Contrary to similar functions found in most popular programming languages, the `
 | `"subject string"` | `` find_last(@, 's') `` |  `0`
 | `"subject string"` | `` find_last(@, 's', `1`) `` |  `8`
 | `"subject string"` | `` find_last(@, 's', `0`, `7`) `` |  `0`
+| `"subject string"` | `` find_last(@, '') `` |  `null`
 
 ### lower
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -57,6 +57,8 @@ The `$start` and `$end` parameters are optional and allow restricting to the sli
 - If `$start` is omitted, it defaults to `0` (which is the start of the `$subject` string).
 - If `$end` is omitted, it defaults to `length(subject)` (which is past the end of the `$subject` string).
 
+If not omitted, the `$start` or `$end` arguments are expected to be integers. Otherwise, an error MUST be raised.
+
 Contrary to similar functions found in most popular programming languages, the `find_first()` function does not return `-1` if no occurrence of the substring can be found. Instead, it returns `null` for consistency reasons with how JMESPath behaves.
 
 ### Examples

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -67,7 +67,7 @@ Contrary to similar functions found in most popular programming languages, the `
 | `"subject string"` | `` find_last(@, 'string', `9`) `` |  `null`
 | `"subject string"` | `` find_last(@, 's') `` |  `0`
 | `"subject string"` | `` find_last(@, 's', `1`) `` |  `8`
-| `"subject string"` | `` find_last(@, 's', `0`, `7`) `` |  `8`
+| `"subject string"` | `` find_last(@, 's', `0`, `7`) `` |  `0`
 
 ### lower
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -48,7 +48,7 @@ Contrary to similar functions found in most popular programming languages, the `
 ### find_last
 
 ```
-int find_last(string $subject, string $sub[, int $start[, $end]])
+int find_last(string $subject, string $sub[, int $start[, int $end]])
 ```
 Given the `$subject` string, `find_last()` returns the zero-based index of the last occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_first()` return `null`.
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -62,11 +62,12 @@ Contrary to similar functions found in most popular programming languages, the `
 | Given | Expression | Result
 |---|---|---
 | `"subject string"` | `` find_last(@, 'string') `` |  `8`
-| `"subject string"` | `` find_last(@, 'string', 8) `` |  `8`
-| `"subject string"` | `` find_last(@, 'string', 8, 9) `` |  `null`
-| `"subject string"` | `` find_last(@, 'string', 9) `` |  `null`
-| `"subject string"` | `` find_last(@, 's', 1) `` |  `8`
+| `"subject string"` | `` find_last(@, 'string', `8`) `` |  `8`
+| `"subject string"` | `` find_last(@, 'string', `8`, `9`) `` |  `null`
+| `"subject string"` | `` find_last(@, 'string', `9`) `` |  `null`
 | `"subject string"` | `` find_last(@, 's') `` |  `0`
+| `"subject string"` | `` find_last(@, 's', `1`) `` |  `8`
+| `"subject string"` | `` find_last(@, 's', `0`, `7`) `` |  `8`
 
 ### lower
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -50,7 +50,7 @@ Contrary to similar functions found in most popular programming languages, the `
 ```
 int find_last(string $subject, string $sub[, int $start[, int $end]])
 ```
-Given the `$subject` string, `find_last()` returns the zero-based index of the last occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_first()` return `null`.
+Given the `$subject` string, `find_last()` returns the zero-based index of the last occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_first()` returns `null`.
 
 The `$start` and `$end` parameters are optional and allow restricting to the slice `[$start:$end]` the range within `$subject` in which `$sub` must be found.
 

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -40,7 +40,7 @@ Contrary to similar functions found in most popular programming languages, the `
 | `"subject string"` | `` find_first(@, 'string', `8`) `` |  `8`
 | `"subject string"` | `` find_first(@, 'string', `9`) `` |  `null`
 | `"subject string"` | `` find_first(@, 's') `` |  `0`
-| `"subject string"` | `` find_first(@, 's', 1) `` |  `8`
+| `"subject string"` | `` find_first(@, 's', `1`) `` |  `8`
 | `"subject string"` | `` find_first(@, '') `` |  `null`
 
 ### find_last


### PR DESCRIPTION
The `find_last()` function now operates like `find_first()` but returns the last index where the search substring appears.
Clarified that those functions operate on the `[$start, $end]` slice range to search for the occurence of the substring.