### PR TITLE
Fix non-controversial raw string literal examples

### DIFF
--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -637,8 +637,7 @@ raw-string-escape = escape ("'" / escape)
 ;; search('foo', "") -> "foo"
 ;; search(' bar ', "") -> " bar "
 ;; search('[baz]', "") -> "[baz]"
-;; search('[baz]', "") -> "[baz]"
-;; search('\u03a6', "") -> "\u03a6"
+;; search('\u03bB', "") -> "\\u03bB"
 ;; search('\\', "") -> "\\"
 ;; ```
 


### PR DESCRIPTION
* Remove duplicate example.
* Fix `\u…` example to clearly demonstrate lack of interpretation by mixed-case preservation.