### PR TITLE
Raw-string literals support C0 control characters.

### DIFF
--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -612,7 +612,7 @@ expression-type     = "&" expression
 
 raw-string        = "'" *raw-string-char "'" ;; # Raw String Literals \
 raw-string-char   = (%x00-26 / %x28-5B / %x5D-10FFFF) / preserved-escape / raw-string-escape ;; \
-preserved-escape  = escape (%x20-26 / %x28-5B / %x5D-10FFFF) ;; \
+preserved-escape  = escape (%x00-26 / %x28-5B / %x5D-10FFFF) ;; \
 raw-string-escape = escape ("'" / escape)
 ;; A raw string is an expression that allows for a literal string value to be specified. The result of evaluating the raw
 ;; string literal expression is the literal string value. It is a simpler form of a literal expression that is special
@@ -639,6 +639,7 @@ raw-string-escape = escape ("'" / escape)
 ;; search('[baz]', "") -> "[baz]"
 ;; search('\u03bB', "") -> "\\u03bB"
 ;; search('foo␊bar', "") -> "foo\nbar"
+;; search('foo\␊bar', "") -> "foo\\\nbar"
 ;; search('\\', "") -> "\\"
 ;; ```
 

--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -611,7 +611,7 @@ expression-type     = "&" expression
 ;; This provides a simple mechanism to explicitly convert types when needed.
 
 raw-string        = "'" *raw-string-char "'" ;; # Raw String Literals \
-raw-string-char   = (%x20-26 / %x28-5B / %x5D-10FFFF) / preserved-escape / raw-string-escape ;; \
+raw-string-char   = (%x00-26 / %x28-5B / %x5D-10FFFF) / preserved-escape / raw-string-escape  ;; \
 preserved-escape  = escape (%x20-26 / %x28-5B / %x5D-10FFFF) ;; \
 raw-string-escape = escape ("'" / escape)
 ;; A raw string is an expression that allows for a literal string value to be specified. The result of evaluating the raw

--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -638,6 +638,7 @@ raw-string-escape = escape ("'" / escape)
 ;; search(' bar ', "") -> " bar "
 ;; search('[baz]', "") -> "[baz]"
 ;; search('\u03bB', "") -> "\\u03bB"
+;; search('foo␊bar', "") -> "foo\nbar"
 ;; search('\\', "") -> "\\"
 ;; ```
 

--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -611,7 +611,7 @@ expression-type     = "&" expression
 ;; This provides a simple mechanism to explicitly convert types when needed.
 
 raw-string        = "'" *raw-string-char "'" ;; # Raw String Literals \
-raw-string-char   = (%x00-26 / %x28-5B / %x5D-10FFFF) / preserved-escape / raw-string-escape  ;; \
+raw-string-char   = (%x00-26 / %x28-5B / %x5D-10FFFF) / preserved-escape / raw-string-escape ;; \
 preserved-escape  = escape (%x20-26 / %x28-5B / %x5D-10FFFF) ;; \
 raw-string-escape = escape ("'" / escape)
 ;; A raw string is an expression that allows for a literal string value to be specified. The result of evaluating the raw


### PR DESCRIPTION
Addresses https://github.com/jmespath-community/jmespath.test/issues/14.

I suggest we should document existing support for C0 control characters in `raw-string` literals as [per JEP-12 example](https://github.com/jmespath-community/jmespath.spec/blob/main/jep-012-raw-string-literals.md#examples).

However, I suggest we should not support C0 control charactes in the `preserved-escape` rule as I think that you be confusing.