### PR TITLE
Fix typos in JEPs

### DIFF
--- a/jep-003-functions.md
+++ b/jep-003-functions.md
@@ -3,7 +3,7 @@
 
 |||
 |---|---
-| **JEP**    | 1
+| **JEP**    | 3
 | **Author** | Michael Dowling, James Saryerwinnie
 | **Status** | accepted
 | **Created**| 27-Nov-2013

--- a/jep-012-raw-string-literals.md
+++ b/jep-012-raw-string-literals.md
@@ -3,7 +3,7 @@
 |||
 |---|---
 | **JEP**    | 12
-| **Author** | Michael Downling
+| **Author** | Michael Dowling
 | **Status** | accepted
 | **Created**| 09-Apr-2015
 


### PR DESCRIPTION
These appear to be simple mistakes in copying from https://github.com/jmespath/jmespath.site/tree/HEAD/docs/proposals .