### PR TITLE
[JEP-14a] Clarified error type precedence.

### DIFF
--- a/jep-014a-string-functions.md
+++ b/jep-014a-string-functions.md
@@ -2,12 +2,18 @@
 
 |||
 |---|---
-| **JEP**    |  14
+| **JEP**    | 14a
 | **Author** | Maxime Labelle, Chris Armstrong (GorillaStack), Richard Gibson
 | **SemVer** | MINOR
-| **Status**| accepted
+| **Status**| draft
 | **Created**| 13-October-2022
-| **Obsoleted by**| [JEP-14a](./jep-014a-string-functions.md)
+| **Obsoletes**| [JEP-14](./jep-014-string-functions.md)
+
+## Addendum
+
+|Date|Description
+|---|---|
+|15-March-2023|Clarified error type precedence.
 
 ## Abstract
 
@@ -22,7 +28,10 @@ _Functions can ~~either~~ have a specific arity, **a range of valid – minimum 
 Some functions accept number arguments which are further constrained to integers or even non-negative integers. This JEP specifies a new error
 type `invalid-value` by updating the paragraph on type constraints from the specification like so:
 
-_Each function signature declares the types of its input parameters. If any type constraints are not met, implementations must indicate that an `invalid-type` error occurred. **If a function parameter accepts values constrained to a specific subset of a type and those constraints are not met, implementations must report that an `invalid-value` error occurred. How and when those errors are raised is implementation specific.**_
+_Each function signature declares the types of its input parameters. If any type constraints are not met, implementations must indicate that an `invalid-type` error occurred. **If a function parameter accepts values constrained to a specific subset of a type and those constraints are not met, implementations must report that an `invalid-value` error occurred.**_
+
+_The [initial version of this JEP](./jep-014-string-functions.md) had a provision stating that_ “How and when those errors are raised is implementation specific”. _This provision has been removed. Implementation must perform type-checking for all function parameters_ before _attempting to evaluate the set of valid values for a given type._
+
 
 ### find_first
 


### PR DESCRIPTION
See [jmespath.test/#28](https://github.com/jmespath-community/jmespath.test/pull/28).

This PR brings the following changes:

```patch
    _Each function signature declares the types of its input parameters. If any type constraints are not met,
    implementations must indicate that an `invalid-type` error occurred. **If a function parameter accepts values
    constrained to a specific subset of a type and those constraints are not met, implementations must report
-   that an `invalid-value` error occurred.**_
+   that an `invalid-value` error occurred. How and when those errors are raised is implementation specific.**_

+   _The [initial version of this JEP](./jep-014-string-functions.md) had a provision stating that_ “How and when those
+   errors are raised is implementation specific”. _This provision has been removed. Implementation must perform
+   type-checking for all function parameters_ before _attempting to evaluate the set of valid values for a given type._
```