### PR TITLE
[JEP-3a] Functions - Clarified string data type and containment.

### DIFF
--- a/functions/contains.yml
+++ b/functions/contains.yml
@@ -14,13 +14,16 @@ returns:
   desc: ''
 desc: |
   Returns `true` if the given `$subject` contains the provided `$search`
-  string.
+  value.
 
   If `$subject` is an array, this function returns true if one of the elements
   in the array is equal to the provided `$search` value.
 
   If the provided `$subject` is a string, this function returns true if
-  the string contains the provided `$search` argument.
+  there exists within the `$subject` string at least one occurrence
+  of an equal `$search` string. If the `$search` value is not a string,
+  the function MUST return `false`.
+
 examples:
   test0:
     context:

--- a/jep-003-functions.md
+++ b/jep-003-functions.md
@@ -3,10 +3,10 @@
 
 |||
 |---|---
-| **JEP**       | 3
-| **Author**    | Michael Dowling, James Saryerwinnie
-| **Status**    | accepted
-| **Created**   | 27-Nov-2013
+| **JEP**          | 3
+| **Author**       | Michael Dowling, James Saryerwinnie
+| **Status**       | accepted
+| **Created**      | 27-Nov-2013
 | **Obsoleted by** | [JEP-003a](./jep-003a-functions.md)
 
 ## Abstract
@@ -36,7 +36,7 @@ used:
 * number (integers and double-precision floating-point format in JSON)
 
 
-* string (a sequence of Unicode [code points](https://unicode.org/glossary/#code_point). Note that a code point is distinct to a [code unit](https://unicode.org/glossary/#code_unit))
+* string
 
 
 * boolean (`true` or `false`)
@@ -305,19 +305,17 @@ Returns the next highest integer value by rounding up if necessary.
 ### contains
 
 ```
-boolean contains(array|string $subject, any $search)
+boolean contains(array|string $subject, array|object|string|number|boolean $search)
 ```
 
 Returns `true` if the given `$subject` contains the provided `$search`
-value.
+string.
 
 If `$subject` is an array, this function returns true if one of the elements
 in the array is equal to the provided `$search` value.
 
 If the provided `$subject` is a string, this function returns true if
-there exists within the `$subject` string at least one _equal_ occurrence
-of the `$search` string. If the `$search` value is not a string, the
-function MUST return `false`.
+the string contains the provided `$search` argument.
 
 #### Examples
 

--- a/jep-003a-functions.md
+++ b/jep-003a-functions.md
@@ -3,11 +3,11 @@
 
 |||
 |---|---
-| **JEP**       | 3
-| **Author**    | Michael Dowling, James Saryerwinnie
+| **JEP**       | 3a
+| **Author**    | Michael Dowling, James Saryerwinnie, Maxime Labelle
 | **Status**    | accepted
 | **Created**   | 27-Nov-2013
-| **Obsoleted by** | [JEP-003a](./jep-003a-functions.md)
+| **Obsoletes** | [JEP-003](./jep-003-functions.md)
 
 ## Abstract
 
@@ -36,7 +36,7 @@ used:
 * number (integers and double-precision floating-point format in JSON)
 
 
-* string (a sequence of Unicode [code points](https://unicode.org/glossary/#code_point). Note that a code point is distinct to a [code unit](https://unicode.org/glossary/#code_unit))
+* string
 
 
 * boolean (`true` or `false`)
@@ -305,19 +305,17 @@ Returns the next highest integer value by rounding up if necessary.
 ### contains
 
 ```
-boolean contains(array|string $subject, any $search)
+boolean contains(array|string $subject, array|object|string|number|boolean $search)
 ```
 
 Returns `true` if the given `$subject` contains the provided `$search`
-value.
+string.
 
 If `$subject` is an array, this function returns true if one of the elements
 in the array is equal to the provided `$search` value.
 
 If the provided `$subject` is a string, this function returns true if
-there exists within the `$subject` string at least one _equal_ occurrence
-of the `$search` string. If the `$search` value is not a string, the
-function MUST return `false`.
+the string contains the provided `$search` argument.
 
 #### Examples
 

--- a/jep-003a-functions.md
+++ b/jep-003a-functions.md
@@ -3,11 +3,17 @@
 
 |||
 |---|---
-| **JEP**       | 3a
-| **Author**    | Michael Dowling, James Saryerwinnie, Maxime Labelle
+| **JEP**       | 3
+| **Author**    | Michael Dowling, James Saryerwinnie
 | **Status**    | accepted
 | **Created**   | 27-Nov-2013
 | **Obsoletes** | [JEP-003](./jep-003-functions.md)
+
+## Addendum
+
+|Date|Description
+|---|---|
+|16-March-2023|Clarified string data type and containment.
 
 ## Abstract
 
@@ -36,7 +42,7 @@ used:
 * number (integers and double-precision floating-point format in JSON)
 
 
-* string
+* string (a sequence of Unicode [code points](https://unicode.org/glossary/#code_point). Note that a code point is distinct to a [code unit](https://unicode.org/glossary/#code_unit))
 
 
 * boolean (`true` or `false`)
@@ -305,17 +311,19 @@ Returns the next highest integer value by rounding up if necessary.
 ### contains
 
 ```
-boolean contains(array|string $subject, array|object|string|number|boolean $search)
+boolean contains(array|string $subject, any $search)
 ```
 
 Returns `true` if the given `$subject` contains the provided `$search`
-string.
+value.
 
 If `$subject` is an array, this function returns true if one of the elements
 in the array is equal to the provided `$search` value.
 
 If the provided `$subject` is a string, this function returns true if
-the string contains the provided `$search` argument.
+there exists within the `$subject` string at least one _equal_ occurrence
+of the `$search` string. If the `$search` value is not a string, the
+function MUST return `false`.
 
 #### Examples
 

--- a/jep-003a-functions.md
+++ b/jep-003a-functions.md
@@ -3,8 +3,8 @@
 
 |||
 |---|---
-| **JEP**       | 3
-| **Author**    | Michael Dowling, James Saryerwinnie
+| **JEP**       | 3a
+| **Author**    | Michael Dowling, James Saryerwinnie, Maxime Labelle
 | **Status**    | accepted
 | **Created**   | 27-Nov-2013
 | **Obsoletes** | [JEP-003](./jep-003-functions.md)


### PR DESCRIPTION
See [discussion/121](https://github.com/jmespath-community/jmespath.spec/discussions/121#discussioncomment-4546056).

This PR brings the following changes:

```patch
    In order to support functions, a type system is needed.  The JSON types are used:
    
    * number (integers and double-precision floating-point format in JSON)
-   * string
+   * string (a sequence of Unicode code points. Note that a code point is distinct to a code unit)
```

and:

```patch
    ```
-   boolean contains(array|string $subject, array|object|string|number|boolean $search)
+   boolean contains(array|string $subject, any $search)
    ```

    Returns `true` if the given `$subject` contains the provided `$search`
-   string.
+   value.

    If `$subject` is an array, this function returns true if one of the elements
    in the array is equal to the provided `$search` value.

    If the provided `$subject` is a string, this function returns true if
-   the string contains the provided `$search` argument.
+   there exists within the `$subject` string at least one _equal_ occurrence
+   of the `$search` string. If the `$search` value is not a string, the
+   function MUST return `false`.
```