### PR TITLE
Editorial changes to indicate the exact error type

### DIFF
--- a/GRAMMAR.ABNF
+++ b/GRAMMAR.ABNF
@@ -341,7 +341,7 @@ slice-expression  = [number] ":" [number] [ ":" [number] ] ;; ## Slices
 ;; - If no `stop` position is given, it is assumed to be the length of the array or string if the given `step` is greater than `0` or `0` if
 ;;   the given `step` is less than `0`.
 ;; - If the given `step` is omitted, it it assumed to be `1`.
-;; - If the given `step` is `0`, an error MUST be raised.
+;; - If the given `step` is `0`, an `invalid-value` error MUST be raised.
 ;; - If the element being sliced is not an array or a string, the result is `null`.
 ;; - If the element being sliced is an array or string and yields no results, the result MUST be an empty array.
 ;;

--- a/function_schema.yml
+++ b/function_schema.yml
@@ -109,6 +109,7 @@ definitions:
     type: string
     enum:
       - invalid-arity
+      - invalid-value
       - invalid-type
       - not-a-number
       - syntax

--- a/functions/abs.yml
+++ b/functions/abs.yml
@@ -12,7 +12,7 @@ returns:
 desc: |
   Returns the absolute value of the provided argument.  The signature indicates
   that a number is returned, and that the input argument `$value` **must**
-  resolve to a number, otherwise a `invalid-type` error is triggered.
+  resolve to a number, otherwise an `invalid-type` error is triggered.
 
   Below is a worked example.  Given:
 

--- a/functions/group_by.yml
+++ b/functions/group_by.yml
@@ -23,7 +23,7 @@ desc: |
   This includes objects for which applying the `$expr` expression evaluates to `null`.
 
   If the result of applying the `$expr` expression against the current array element
-  results in type other than `string` or `null`, a type error MUST be raised.
+  results in type other than `string` or `null`, an `invalid-type` error MUST be raised.
 examples:
   group_by:
     context:

--- a/functions/sort_by.yml
+++ b/functions/sort_by.yml
@@ -18,7 +18,7 @@ desc: |
   resulting value is used as the key used when sorting the `elements`.
 
   If the result of evaluating the `expr` against the current array element
-  results in type other than a `number` or a `string`, a type error will
+  results in type other than a `number` or a `string`, an `invalid-type` error will
   occur.
 
   Below are several examples using the `people` array (defined above) as the

--- a/jep-003-functions.md
+++ b/jep-003-functions.md
@@ -189,7 +189,7 @@ number abs(number $value)
 
 Returns the absolute value of the provided argument.  The signature indicates
 that a number is returned, and that the input argument `$value` **must**
-resolve to a number, otherwise a `invalid-type` error is triggered.
+resolve to a number, otherwise an `invalid-type` error is triggered.
 
 Below is a worked example.  Given:
 

--- a/jep-003a-functions.md
+++ b/jep-003a-functions.md
@@ -195,7 +195,7 @@ number abs(number $value)
 
 Returns the absolute value of the provided argument.  The signature indicates
 that a number is returned, and that the input argument `$value` **must**
-resolve to a number, otherwise a `invalid-type` error is triggered.
+resolve to a number, otherwise an `invalid-type` error is triggered.
 
 Below is a worked example.  Given:
 

--- a/jep-005-array-slices.md
+++ b/jep-005-array-slices.md
@@ -86,7 +86,7 @@ the given step is greater than 0 or 0 if the given step is less than 0.
 5. If the given step is omitted, it it assumed to be 1.
 
 
-6. If the given step is 0, an error must be raised.
+6. If the given step is 0, an `invalid-value` error must be raised.
 
 
 7. If the element being sliced is not an array, the result must be `null`.

--- a/jep-018-grouping.md
+++ b/jep-018-grouping.md
@@ -30,7 +30,7 @@ Objects that do not match the group criteria are discarded from the output.
 This includes objects for which applying the `$expr` expression evaluates to `null`.
 
 If the result of applying the `$expr` expression against the current array element
-results in type other than `string` or `null`, a type error MUST be raised.
+results in type other than `string` or `null`, an `invalid-type` error MUST be raised.
 
 ### Examples
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to the JMESPath Specification.

Before creating a pull request, please ensure that the feature or change has been fully discussed in a discussion and the discussion has been assigned a JEP tag.

This PR should include a JEP specification file based off TEMPLATE.md, named with the pattern "jep-###-title.md", and a compliance test json in either
grammar/ or functions/ as appropriate.
Additionally, the PR should include any intended modifications to the GRAMMAR.ABNF file.

Please complete the required sections below:
-->


# Editorial changes to indicate the exact error type

|||
|---|---
| **JEP**    | 
| **Author** | \<author>
| **Created**| \<date>
| **[SemVer](https://semver.org/spec/v2.0.0.html#summary)** | MAJOR\|MINOR\|PATCH
| **[Discussion #](https://github.com/jmespath-community/jmespath.jep/discussions)** | [##](https://github.com/jmespath-community/jmespath.jep/discussions/##)

*Please discuss the merit of the JEP in the linked discussion. PR discussion should be limited to proofing the content of the PR and the PR proposal initial comment*

I don't understand why a JEP is needed. This is a lot of overhead just to submit a small editorial change.

## Abstract

This PR changes the wording of the spec to state the specific error type in all error scenarios.

I have found several occurrences of the word "error" in the spec. In most cases, the spec indicates the exact type of error, e.g., `invalid-type`, `unknown-function`, `invalid-arity`. However, there were a few occurrences when no explicit error type is mentioned.

In two cases, I think the right error type is ``invalid-type``. In the third case (**Slices** section), I'm not sure what the error type should be. Maybe `invalid-value`, but it's not specified anywhere in the spec (I see only three error types defined).

```diff
- If the given step is 0, an error MUST be raised.
+ If the given step is 0, an `invalid-value` error MUST be raised.
```


## Implementation Survey

Not relevant
