### PR TITLE
docs: fix typos in JEP-010 and JEP-014 specifications

### DIFF
--- a/jep-010-slice-projections.md
+++ b/jep-010-slice-projections.md
@@ -66,7 +66,7 @@ sub arrays are merged before passing the expression onto the right hand
 side.
 
 It’s a reasonable expectation that slices behave similar.  After all,
-slices take an array and produce a sub array.  It many ways, it’s very
+slices take an array and produce a sub array.  In many ways, it’s very
 similar to filter projections.  While filter projections only include
 elements that match a particular expression, slice projections
 only include elements from and to a specific index.  Given its semantics
@@ -75,7 +75,7 @@ to be consistent.
 
 ## Specification
 
-Whenver a slice is created, a projection will be created. This will be the
+Whenever a slice is created, a projection will be created. This will be the
 fourth type of array projection in JMESPath.  In addition to the existing array
 projections:
 
@@ -92,7 +92,7 @@ A new projection type, the slice projection will be added.  A slice projection
 is evaluated similar to the other array projections.  Given a slice projection
 which contains a left hand side containing the slice expression and a right
 hand side, the slice expression is evaluated to create a new sub array, and
-each expression on the right hand side is evaluted against each element from
+each expression on the right hand side is evaluated against each element from
 the array slice to create the final result.
 
 This JEP does not include any modifications to the JMESPath grammar.

--- a/jep-014-string-functions.md
+++ b/jep-014-string-functions.md
@@ -61,7 +61,7 @@ Contrary to similar functions found in most popular programming languages, the `
 ```
 int find_last(string $subject, string $sub[, int $start[, int $end]])
 ```
-Given the `$subject` string, `find_last()` returns the zero-based index of the last occurence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_last()` returns `null`.
+Given the `$subject` string, `find_last()` returns the zero-based index of the last occurrence where the `$sub` substring appears in `$subject` or `null` if it does not appear. If either the `$subject` or the `$sub` argument is an empty string, `find_last()` returns `null`.
 
 The `$start` and `$end` parameters are optional and allow restricting to the slice `[$start:$end]` the range within `$subject` in which `$sub` must be found.
 
@@ -175,7 +175,7 @@ The `replace()` function has no effect if `$count` is `0`.
 array[string] split(string $subject, string $search[, number $count])
 ```
 
-Given the `$subject` string, `split()` breaks on ocurrences of the string `$search` and returns an array.
+Given the `$subject` string, `split()` breaks on occurrences of the string `$search` and returns an array.
 
 The `split()` function returns an array containing each partial string between occurrences of `$search`. If  `$subject` contains no occurrences of the `$search` string, an array containing just the original `$subject` string will be returned.
 
@@ -188,7 +188,7 @@ If `$count` is equal to `0`, `split()` returns an array containing a single elem
 
 Otherwise, the `split()` function breaks on occurrences of the `$search` string up to `$count` times. The last string in the resulting array containing the remaining contents of `$subject` unmodified.
 
-**Note**: The `split()` function was [originally designed by Chris Armstrong](https://github.com/GorillaStack/jmespath.site/blob/master/docs/proposals/string-manipulation.rst). However, its behaviour has been slightly altered for consistency reasons.
+**Note**: The `split()` function was [originally designed by Chris Armstrong](https://github.com/GorillaStack/jmespath.site/blob/master/docs/proposals/string-manipulation.rst). However, its behavior has been slightly altered for consistency reasons.
 
 ### Examples
 


### PR DESCRIPTION
Fix various spelling errors:
- "Whenver" -> "Whenever"
- "It many ways" -> "In many ways"
- "evaluted" -> "evaluated"
- "occurence(s)" -> "occurrence(s)"
- "behaviour" -> "behavior"

<!-- ps-id: 3ac38b21-39d5-49f1-8d01-80cb0cc4999f -->